### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 license = "Apache-2.0"
 categories = ["algorithms"]
 repository = "https://github.com/openrr/ros-nalgebra"
-readme = "README.md"
 
 [dependencies]
 


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (`readme = "README.md"`).

